### PR TITLE
missing cancel_return in schema - used in default config

### DIFF
--- a/src/Model/Endpoint/Schema/PaypalButtonSchema.php
+++ b/src/Model/Endpoint/Schema/PaypalButtonSchema.php
@@ -106,5 +106,11 @@ class PaypalButtonSchema extends Schema
                'comment' => 'custom URL to return to after a successful sale',
          ]);
 
+         $this->addColumn(
+            'cancel_return', [
+               'type' => 'string',
+               'null' => true,
+               'comment' => 'cancel URL to return to after cancelled sale',
+         ]);
     }
 }


### PR DESCRIPTION
it's possible to set a "cancel_return" in the default config, but not to override it later.
adding it to the schema passes it into the create/update queries.